### PR TITLE
Compile time parsing support

### DIFF
--- a/src/fastpnm.nim
+++ b/src/fastpnm.nim
@@ -255,7 +255,8 @@ func parsePnmContent(s: string, offset: int, result: var Pnm) =
         for n in findInts(s, offset):
             result.data.add n.byte
     of compressed:
-        result.data = cast[seq[byte]](s[offset..s.high])
+        for n in offset..s.high:
+            result.data.add s[n].byte
 
 func parsePnm*(s: string, captureComments = false): Pnm =
     ## parses your `.pnm`, `.pbm`, `.pgm`, `.ppm` files

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,4 +1,4 @@
-import std/[unittest, os, strformat, sequtils, strutils]
+import std/[unittest, os, strformat, sequtils, strutils, macros]
 import fastpnm
 
 
@@ -130,3 +130,19 @@ suite "comments":
     ppp.comment = c
     let again = parsePnm(`$`(ppp, addComments = true), true)
     checkSame ppp, again
+
+suite "Compile time parsing":
+
+  template assertStaticParsing(path: string) =
+    const compiletime = parsePnm staticRead(getProjectPath() / ".." / path)
+    let runtime = parsePnm readfile path
+    checkSame(compiletime, runtime)
+
+  test "P1":
+    assertStaticParsing("examples/j.pbm")
+
+  test "P2":
+    assertStaticParsing("examples/4x6.pgm")
+
+  test "P3":
+    assertStaticParsing("examples/colorful.ppm")


### PR DESCRIPTION
This change adds support for loading files at compile time. Without this, the following error is raised:

```
/home/nycto/Code/fastpnm/src/fastpnm.nim(258, 23) Error: VM does not support 'cast' from tyString to tySequence
```